### PR TITLE
avoid registering the same assembly more than once

### DIFF
--- a/src/GitInformation/AraHaan.GitInformation/GitInformation.cs
+++ b/src/GitInformation/AraHaan.GitInformation/GitInformation.cs
@@ -25,7 +25,11 @@ namespace System.Runtime.InteropServices
             this.Headdesc = headdesc;
             this.Commit = commit;
             this.Branchname = branchname;
-            AssemblyInstances.Add(assembly, this);
+
+            if (!AssemblyInstances.ContainsKey(assembly))
+            {
+                AssemblyInstances.Add(assembly, this);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This is a follow up of https://github.com/dotnet/BenchmarkDotNet/issues/1439 and https://github.com/dotnet/runtime/issues/35832

The ctor of an attribute can be invoked more than once, and trying to add the same key to dictionary ends up with `System.ArgumentException: An item with the same key has already been added.`