### PR TITLE
Minor perf improvements

### DIFF
--- a/src/GitInformation/AraHaan.GitInformation/GitInformation.cs
+++ b/src/GitInformation/AraHaan.GitInformation/GitInformation.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices
     {
         // This is the collection of instances this has.
         private static readonly Dictionary<Assembly, GitInformation> AssemblyInstances = new Dictionary<Assembly, GitInformation>();
-        private static readonly List<Assembly> AppliedAssemblies = new List<Assembly>();
+        private static readonly HashSet<Assembly> AppliedAssemblies = new HashSet<Assembly>();
         /*
         private static bool applied = false;
         */

--- a/src/GitInformation/AraHaan.GitInformation/GitInformation.cs
+++ b/src/GitInformation/AraHaan.GitInformation/GitInformation.cs
@@ -143,6 +143,6 @@ namespace System.Runtime.InteropServices
         /// or <see langword="null"/>.
         /// </returns>
         public static GitInformation GetAssemblyInstance(Assembly assembly)
-            => AssemblyInstances.ContainsKey(assembly) ? AssemblyInstances[assembly] : null;
+            => AssemblyInstances.TryGetValue(assembly, out var gitInformation) ? gitInformation : null;
     }
 }


### PR DESCRIPTION
While working on #39 I've found two places for perf improvements:

* `List.Contains` is `O(n)`, it can be replaced with `HashSet.Contains` which is `O(1)`. Moreover, HashSet ensures uniqueness of the elements
* `dictionary.ContainsKey(key) ? dictionary[key]` requires two lookups, it can be replaced with a single one by using `dictionary.TryGetValue`. It can also avoid running into an issue when the element gets removed in the meantime